### PR TITLE
removing lfx 2025 term 2 project with a mentee w/o a github handle

### DIFF
--- a/000-build-programs/lfx-2025-term2-follow-up.json
+++ b/000-build-programs/lfx-2025-term2-follow-up.json
@@ -208,21 +208,6 @@
       }
     },
     {
-      "username": "its-a-designer-so-maybe-theres-no-github",
-      "mentors": [
-        "joaquimrocha",
-        "ivelisseca"
-      ],
-      "organizations": [
-        "kubernetes-sigs"
-      ],
-      "project": {
-        "title": "CNCF - Headlamp: UX Audit and Design Improvements for Plugins (2025 Term 2)",
-        "ideaUrl": "https://github.com/cncf/mentoring/tree/main/programs/lfx-mentorship/2025/02-Jun-Aug#kubernetes-headlamp-ui-ux-audit-and-design-improvements-for-plugins",
-        "platformUrl": "https://mentorship.lfx.linuxfoundation.org/project/4d736149-aa95-4f31-b01c-a54c754614d0"
-      }
-    },
-    {
       "username": "Emidowojo",
       "mentors": [
         "mayasingh17",

--- a/000-build-programs/lfx-2025-term2.json
+++ b/000-build-programs/lfx-2025-term2.json
@@ -208,21 +208,6 @@
       }
     },
     {
-      "username": "its-a-designer-so-maybe-theres-no-github",
-      "mentors": [
-        "joaquimrocha",
-        "ivelisseca"
-      ],
-      "organizations": [
-        "kubernetes-sigs"
-      ],
-      "project": {
-        "title": "CNCF - Headlamp: UX Audit and Design Improvements for Plugins (2025 Term 2)",
-        "ideaUrl": "https://github.com/cncf/mentoring/tree/main/programs/lfx-mentorship/2025/02-Jun-Aug#kubernetes-headlamp-ui-ux-audit-and-design-improvements-for-plugins",
-        "platformUrl": "https://mentorship.lfx.linuxfoundation.org/project/4d736149-aa95-4f31-b01c-a54c754614d0"
-      }
-    },
-    {
       "username": "Emidowojo",
       "mentors": [
         "mayasingh17",

--- a/programs.json
+++ b/programs.json
@@ -209,21 +209,6 @@
         }
       },
       {
-        "username": "its-a-designer-so-maybe-theres-no-github",
-        "mentors": [
-          "joaquimrocha",
-          "ivelisseca"
-        ],
-        "organizations": [
-          "kubernetes-sigs"
-        ],
-        "project": {
-          "title": "CNCF - Headlamp: UX Audit and Design Improvements for Plugins (2025 Term 2)",
-          "ideaUrl": "https://github.com/cncf/mentoring/tree/main/programs/lfx-mentorship/2025/02-Jun-Aug#kubernetes-headlamp-ui-ux-audit-and-design-improvements-for-plugins",
-          "platformUrl": "https://mentorship.lfx.linuxfoundation.org/project/4d736149-aa95-4f31-b01c-a54c754614d0"
-        }
-      },
-      {
         "username": "Emidowojo",
         "mentors": [
           "mayasingh17",
@@ -1054,21 +1039,6 @@
           "title": "CNCF - Headlamp: Kubernetes API caching, pagination & search (2025 Term 2)",
           "ideaUrl": "https://github.com/cncf/mentoring/tree/main/programs/lfx-mentorship/2025/02-Jun-Aug#kubernetes-ui-headlamp-implement-kubernetes-api-caching-pagination-and-search",
           "platformUrl": "https://mentorship.lfx.linuxfoundation.org/project/1b9a4a99-2d92-4c1a-ac34-7fe554bf6393"
-        }
-      },
-      {
-        "username": "its-a-designer-so-maybe-theres-no-github",
-        "mentors": [
-          "joaquimrocha",
-          "ivelisseca"
-        ],
-        "organizations": [
-          "kubernetes-sigs"
-        ],
-        "project": {
-          "title": "CNCF - Headlamp: UX Audit and Design Improvements for Plugins (2025 Term 2)",
-          "ideaUrl": "https://github.com/cncf/mentoring/tree/main/programs/lfx-mentorship/2025/02-Jun-Aug#kubernetes-headlamp-ui-ux-audit-and-design-improvements-for-plugins",
-          "platformUrl": "https://mentorship.lfx.linuxfoundation.org/project/4d736149-aa95-4f31-b01c-a54c754614d0"
         }
       },
       {


### PR DESCRIPTION
@aliok, i'm removing this project as I'm not actually sure how mentorship monitor handles user errors. I'd  prefer to keep the project listed. Maybe it's better if we set `"username": "",` (blank) instead?